### PR TITLE
feature#36 카테고리상세 화면 기능 추가

### DIFF
--- a/core/android/src/main/java/com/chan/android/CommonProductCard.kt
+++ b/core/android/src/main/java/com/chan/android/CommonProductCard.kt
@@ -2,12 +2,12 @@ package com.chan.android
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -25,12 +25,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
@@ -38,21 +38,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.chan.android.model.ProductModel
-import com.chan.android.R
 
 @Composable
 fun ProductCard(
     product: ProductModel,
-    onClick: () -> Unit,
+    onClick: (productId: String) -> Unit,
     onLikeClick: (productId: String) -> Unit,
     onCartClick: (productId: String) -> Unit,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .fillMaxHeight(),
+            .clickable(
+                onClick = { onClick(product.productId) },
+                indication = null,
+                interactionSource = interactionSource
+            ),
         shape = RoundedCornerShape(8.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent)
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
     ) {
         Column(
             modifier = Modifier

--- a/feature/category/src/main/java/com/chan/category/navigation/detail/CategoryDetailNavGraph.kt
+++ b/feature/category/src/main/java/com/chan/category/navigation/detail/CategoryDetailNavGraph.kt
@@ -17,7 +17,9 @@ class CategoryDetailNavGraph @Inject constructor() : NavGraphProvider {
             route = CategoryDetailDestination.route,
             arguments = CategoryDetailDestination.arguments
         ) { backStackEntry ->
-            val categoryId = backStackEntry.arguments?.getString("categoryId")!!
+            val categoryId = requireNotNull(backStackEntry.arguments?.getString("categoryId")) {
+                "categoryId is required"
+            }
             CategoryDetailScreen(
                 categoryId = categoryId,
                 onProductClick = { productId ->

--- a/feature/category/src/main/java/com/chan/category/navigation/detail/CategoryDetailNavGraph.kt
+++ b/feature/category/src/main/java/com/chan/category/navigation/detail/CategoryDetailNavGraph.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.chan.category.ui.composables.detail.CategoryDetailScreen
 import com.chan.navigation.NavGraphProvider
+import com.chan.navigation.Routes
 import javax.inject.Inject
 
 class CategoryDetailNavGraph @Inject constructor() : NavGraphProvider {
@@ -17,7 +18,14 @@ class CategoryDetailNavGraph @Inject constructor() : NavGraphProvider {
             arguments = CategoryDetailDestination.arguments
         ) { backStackEntry ->
             val categoryId = backStackEntry.arguments?.getString("categoryId")!!
-            CategoryDetailScreen(categoryId = categoryId)
+            CategoryDetailScreen(
+                categoryId = categoryId,
+                onProductClick = { productId ->
+                    navController.navigate(
+                        Routes.PRODUCT_DETAIL.productDetailRoute(productId)
+                    )
+                }
+            )
         }
     }
 }

--- a/feature/category/src/main/java/com/chan/category/ui/CategoryDetailContract.kt
+++ b/feature/category/src/main/java/com/chan/category/ui/CategoryDetailContract.kt
@@ -17,7 +17,7 @@ class CategoryDetailContract {
 
     data class State(
         val loadingState: LoadingState = LoadingState.Idle,
-        val selectedCategoryId: String? = null,
+        val selectedCategoryTabId: String? = null,
         val categoryNames: List<CategoryDetailTabsModel> = emptyList(),
         val categoryDetailList: List<ProductModel> = emptyList()
     ) : ViewState

--- a/feature/category/src/main/java/com/chan/category/ui/CategoryDetailContract.kt
+++ b/feature/category/src/main/java/com/chan/category/ui/CategoryDetailContract.kt
@@ -11,10 +11,13 @@ class CategoryDetailContract {
 
     sealed interface Event : ViewEvent {
         data class CategoryDetailLoad(val categoryId: String) : Event
+
+        data class CategoryTabSelected(val categoryId: String) : Event
     }
 
     data class State(
         val loadingState: LoadingState = LoadingState.Idle,
+        val selectedCategoryId: String? = null,
         val categoryNames: List<CategoryDetailTabsModel> = emptyList(),
         val categoryDetailList: List<ProductModel> = emptyList()
     ) : ViewState

--- a/feature/category/src/main/java/com/chan/category/ui/CategoryDetailViewModel.kt
+++ b/feature/category/src/main/java/com/chan/category/ui/CategoryDetailViewModel.kt
@@ -20,17 +20,18 @@ class CategoryDetailViewModel @Inject constructor(
     override fun handleEvent(event: CategoryDetailContract.Event) {
         when (event) {
             is CategoryDetailContract.Event.CategoryDetailLoad -> {
-                getCategoryTobList(event.categoryId)
+                getCategoryTabList(event.categoryId)
                 getCategoryDetailList(event.categoryId)
             }
 
             is CategoryDetailContract.Event.CategoryTabSelected -> {
+                setState { copy(selectedCategoryTabId = event.categoryId) }
                 getCategoryDetailList(categoryId = event.categoryId)
             }
         }
     }
 
-    private fun getCategoryTobList(categoryId: String) {
+    private fun getCategoryTabList(categoryId: String) {
         handleRepositoryCall(
             call = {
                 categoryDetailRepository.getCategoryDetailTabs(categoryId).map { it.toTabsModel() }
@@ -40,8 +41,6 @@ class CategoryDetailViewModel @Inject constructor(
     }
 
     private fun getCategoryDetailList(categoryId: String) {
-        setState { copy(selectedCategoryTabId = categoryId) }
-
         handleRepositoryCall(
             call = {
                 categoryDetailRepository.getCategoryDetailProducts(categoryId)

--- a/feature/category/src/main/java/com/chan/category/ui/CategoryDetailViewModel.kt
+++ b/feature/category/src/main/java/com/chan/category/ui/CategoryDetailViewModel.kt
@@ -40,7 +40,7 @@ class CategoryDetailViewModel @Inject constructor(
     }
 
     private fun getCategoryDetailList(categoryId: String) {
-        setState { copy(selectedCategoryId = categoryId) }
+        setState { copy(selectedCategoryTabId = categoryId) }
 
         handleRepositoryCall(
             call = {

--- a/feature/category/src/main/java/com/chan/category/ui/CategoryDetailViewModel.kt
+++ b/feature/category/src/main/java/com/chan/category/ui/CategoryDetailViewModel.kt
@@ -20,13 +20,17 @@ class CategoryDetailViewModel @Inject constructor(
     override fun handleEvent(event: CategoryDetailContract.Event) {
         when (event) {
             is CategoryDetailContract.Event.CategoryDetailLoad -> {
-                getSiblingSubCategories(event.categoryId)
+                getCategoryTobList(event.categoryId)
                 getCategoryDetailList(event.categoryId)
+            }
+
+            is CategoryDetailContract.Event.CategoryTabSelected -> {
+                getCategoryDetailList(categoryId = event.categoryId)
             }
         }
     }
 
-    private fun getSiblingSubCategories(categoryId: String) {
+    private fun getCategoryTobList(categoryId: String) {
         handleRepositoryCall(
             call = {
                 categoryDetailRepository.getCategoryDetailTabs(categoryId).map { it.toTabsModel() }
@@ -36,6 +40,8 @@ class CategoryDetailViewModel @Inject constructor(
     }
 
     private fun getCategoryDetailList(categoryId: String) {
+        setState { copy(selectedCategoryId = categoryId) }
+
         handleRepositoryCall(
             call = {
                 categoryDetailRepository.getCategoryDetailProducts(categoryId)

--- a/feature/category/src/main/java/com/chan/category/ui/composables/detail/CategoryDetailScreen.kt
+++ b/feature/category/src/main/java/com/chan/category/ui/composables/detail/CategoryDetailScreen.kt
@@ -39,7 +39,7 @@ fun CategoryDetailScreen(
 
     val state by viewModel.viewState.collectAsState()
     val selectedIndex =
-        state.categoryNames.indexOfFirst { it.categoryId == state.selectedCategoryId }
+        state.categoryNames.indexOfFirst { it.categoryId == state.selectedCategoryTabId }
             .coerceAtLeast(0)
 
 

--- a/feature/category/src/main/java/com/chan/category/ui/composables/detail/CategoryDetailScreen.kt
+++ b/feature/category/src/main/java/com/chan/category/ui/composables/detail/CategoryDetailScreen.kt
@@ -3,6 +3,7 @@ package com.chan.category.ui.composables.detail
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -19,9 +20,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -39,18 +37,13 @@ fun CategoryDetailScreen(
 ) {
 
     val state by viewModel.viewState.collectAsState()
-    var selectedTab by remember { mutableStateOf(0) }
+    val selectedIndex =
+        state.categoryNames.indexOfFirst { it.categoryId == state.selectedCategoryId }
+            .coerceAtLeast(0)
+
 
     LaunchedEffect(categoryId) {
         viewModel.setEvent(CategoryDetailContract.Event.CategoryDetailLoad(categoryId))
-    }
-    LaunchedEffect(state.categoryNames) {
-        if (state.categoryNames.isNotEmpty()) {
-            val initialIndex = state.categoryNames.indexOfFirst { it.categoryId == categoryId }
-            if (initialIndex != -1) {
-                selectedTab = initialIndex
-            }
-        }
     }
 
     Scaffold(
@@ -58,9 +51,14 @@ fun CategoryDetailScreen(
             if (state.categoryNames.isNotEmpty()) {
                 CategoryDetailTopBar(
                     tabs = state.categoryNames,
-                    selectedIndex = selectedTab,
+                    selectedIndex = selectedIndex,
                     onTabSelected = { index ->
-                        selectedTab = index
+                        val selectedCategoryIndex = state.categoryNames[index].categoryId
+                        viewModel.setEvent(
+                            CategoryDetailContract.Event.CategoryTabSelected(
+                                selectedCategoryIndex
+                            )
+                        )
                     }
                 )
             }
@@ -93,6 +91,7 @@ fun CategoryDetailTopBar(
     onTabSelected: (Int) -> Unit
 ) {
     ScrollableTabRow(
+        modifier = Modifier.fillMaxWidth(),
         selectedTabIndex = selectedIndex,
         edgePadding = 16.dp,
         indicator = { tabPositions ->

--- a/feature/category/src/main/java/com/chan/category/ui/composables/detail/CategoryDetailScreen.kt
+++ b/feature/category/src/main/java/com/chan/category/ui/composables/detail/CategoryDetailScreen.kt
@@ -33,7 +33,8 @@ import com.chan.category.ui.model.detail.CategoryDetailTabsModel
 @Composable
 fun CategoryDetailScreen(
     categoryId: String,
-    viewModel: CategoryDetailViewModel = hiltViewModel()
+    viewModel: CategoryDetailViewModel = hiltViewModel(),
+    onProductClick: (String) -> Unit
 ) {
 
     val state by viewModel.viewState.collectAsState()
@@ -75,7 +76,7 @@ fun CategoryDetailScreen(
             ) { product ->
                 ProductCard(
                     product = product,
-                    onClick = {},
+                    onClick = { onProductClick(it) },
                     onLikeClick = {},
                     onCartClick = {}
                 )


### PR DESCRIPTION
### **📌 Issue**
- #36 

### **🔖 요약**
1. 탭 클릭 시, 해당 카테고리 탭에 맞는 리스트 보여주기
2. 상품 클릭 시, 상품 상세 이동

### **🛠 작업 내용**
1. 상품 카테고리 탭 id 상태 추가(`selectedCategoryTabId`) , 클릭 시 해당 탭 id에 맞는 리스트 표시 (`getCategoryDetailList` 호출)
2. 상품 클릭 시, 상품 상세 이동 `click, navGraph` 추가

### **❗️ 참고 사항**
