### PR TITLE
refactor 검색 화면 구조 개선

### DIFF
--- a/feature/search/src/main/java/com/chan/search/ui/composables/SearchFilterScreen.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/SearchFilterScreen.kt
@@ -43,7 +43,7 @@ fun SearchFilterScreen(
         },
         bottomBar = {
             FilterBottomButton(
-                itemCount = state.filteredProductCount,
+                itemCount = state.filter.filteredProductCount,
                 onApplyFilters = { onEvent(SearchContract.Event.Filter.OnFilterClick) }
             )
         }
@@ -55,7 +55,7 @@ fun SearchFilterScreen(
             // "오늘드림", "픽업" 체크박스 섹션
             item {
                 FilterToggleSection(
-                    selectedOption = state.selectedDeliveryOption,
+                    selectedOption = state.filter.selectedDeliveryOption,
                     onOptionClick = { onEvent(SearchContract.Event.Filter.OnDeliveryOptionChanged(it)) }
                 )
                 HorizontalDivider(
@@ -70,7 +70,7 @@ fun SearchFilterScreen(
                 //카테고리
                 ExpandableFilterSection(
                     title = stringResource(R.string.category_label),
-                    isExpanded = state.isCategorySectionExpanded,
+                    isExpanded = state.filter.isCategorySectionExpanded,
                     onClick = { onEvent(SearchContract.Event.Filter.OnCategoryClick) }
                 )
                 HorizontalDivider(
@@ -78,11 +78,11 @@ fun SearchFilterScreen(
                     thickness = 1.dp
                 )
                 //서브 카테고리
-                if (state.isCategorySectionExpanded) {
+                if (state.filter.isCategorySectionExpanded) {
                     SubFilterCategory(
-                        categoryFilters = state.categoryFilters,
-                        expandedCategoryName = state.expandedCategoryName,
-                        selectedSubCategories = state.selectedSubCategories,
+                        categoryFilters = state.filter.categoryFilters,
+                        expandedCategoryName = state.filter.expandedCategoryName,
+                        selectedSubCategories = state.filter.selectedSubCategories,
                         onCategoryHeaderClick = {
                             onEvent(
                                 SearchContract.Event.Filter.OnCategoryHeaderClick(
@@ -283,5 +283,7 @@ fun FilterBottomButton(
         )
     }
 }
+
+
 
 

--- a/feature/search/src/main/java/com/chan/search/ui/composables/SearchFilterScreen.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/SearchFilterScreen.kt
@@ -37,14 +37,14 @@ fun SearchFilterScreen(
         containerColor = White,
         topBar = {
             FilterHeader(
-                onClose = { onEvent(SearchContract.Event.OnUpdateFilterClick) },
-                onFilterClear = { onEvent(SearchContract.Event.OnFilterClear) }
+                onClose = { onEvent(SearchContract.Event.Filter.OnFilterClick) },
+                onFilterClear = { onEvent(SearchContract.Event.Filter.OnClear) }
             )
         },
         bottomBar = {
             FilterBottomButton(
                 itemCount = state.filteredProductCount,
-                onApplyFilters = { onEvent(SearchContract.Event.OnUpdateFilterClick) }
+                onApplyFilters = { onEvent(SearchContract.Event.Filter.OnFilterClick) }
             )
         }
     ) { paddingValues ->
@@ -56,7 +56,7 @@ fun SearchFilterScreen(
             item {
                 FilterToggleSection(
                     selectedOption = state.selectedDeliveryOption,
-                    onOptionClick = { onEvent(SearchContract.Event.OnDeliveryOptionChanged(it)) }
+                    onOptionClick = { onEvent(SearchContract.Event.Filter.OnDeliveryOptionChanged(it)) }
                 )
                 HorizontalDivider(
                     color = Color.LightGray.copy(alpha = 0.2f),
@@ -71,7 +71,7 @@ fun SearchFilterScreen(
                 ExpandableFilterSection(
                     title = stringResource(R.string.category_label),
                     isExpanded = state.isCategorySectionExpanded,
-                    onClick = { onEvent(SearchContract.Event.OnFilterCategoryClick) }
+                    onClick = { onEvent(SearchContract.Event.Filter.OnCategoryClick) }
                 )
                 HorizontalDivider(
                     color = Color.LightGray.copy(alpha = 0.5f),
@@ -85,12 +85,12 @@ fun SearchFilterScreen(
                         selectedSubCategories = state.selectedSubCategories,
                         onCategoryHeaderClick = {
                             onEvent(
-                                SearchContract.Event.OnCategoryHeaderClick(
+                                SearchContract.Event.Filter.OnCategoryHeaderClick(
                                     it
                                 )
                             )
                         },
-                        onSubCategoryClick = { onEvent(SearchContract.Event.OnSubCategoryClick(it)) }
+                        onSubCategoryClick = { onEvent(SearchContract.Event.Filter.OnSubCategoryClick(it)) }
                     )
                 }
             }
@@ -283,4 +283,5 @@ fun FilterBottomButton(
         )
     }
 }
+
 

--- a/feature/search/src/main/java/com/chan/search/ui/composables/SearchScreen.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/SearchScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
-import com.chan.search.ui.contract.SearchContract
 import com.chan.search.ui.viewmodel.SearchViewModel
 
 @Composable
@@ -17,39 +16,7 @@ fun SearchScreen(
 
     SearchScreenContent(
         navController = navController,
-        search = state.search,
-        recentSearches = state.recentSearches,
-        recommendedKeywords = state.recommendedKeywords,
-        trendingSearches = state.trendingSearches,
-        searchResults = state.searchResults,
-        currentTime = state.currentTime,
-        showSearchResult = state.showSearchResult,
-        searchResultProducts = state.searchResultProducts,
-        showFilter = state.showFilter,
-        selectedDeliveryOption = state.selectedDeliveryOption,
-        categoryFilters = state.categoryFilters,
-        expandedCategoryName = state.expandedCategoryName,
-        selectedSubCategories = state.selectedSubCategories,
-        isCategorySectionExpanded = state.isCategorySectionExpanded,
-        filteredProductCount = state.filteredProductCount,
-        onSearchChanged = { viewModel.setEvent(SearchContract.Event.OnSearchChanged(it)) },
-        onClearSearch = { viewModel.setEvent(SearchContract.Event.OnClickClearSearch) },
-        onSearchClick = { viewModel.setEvent(SearchContract.Event.OnAddSearchKeyword(it)) },
-        onSearchTextFocus = { viewModel.setEvent(SearchContract.Event.OnSearchTextFocus) },
-        onRemoveSearchKeyword = { viewModel.setEvent(SearchContract.Event.OnRemoveSearchKeyword(it)) },
-        onClearAllRecentSearches = { viewModel.setEvent(SearchContract.Event.OnClearAllRecentSearches) },
-        onSearchResultItemClick = { viewModel.setEvent(SearchContract.Event.OnClickSearchProduct(it)) },
-        onFilterClear = { viewModel.setEvent(SearchContract.Event.OnFilterClear) },
-        onUpdateFilterClick = { viewModel.setEvent(SearchContract.Event.OnUpdateFilterClick) },
-        onDeliveryOptionClick = { viewModel.setEvent(SearchContract.Event.OnDeliveryOptionChanged(it)) },
-        onCategoryHeaderClick = { viewModel.setEvent(SearchContract.Event.OnCategoryHeaderClick(it)) },
-        onSubCategoryClick = { viewModel.setEvent(SearchContract.Event.OnSubCategoryClick(it)) },
-        onFilterCategoryClick = { viewModel.setEvent(SearchContract.Event.OnFilterCategoryClick) },
-        onClickBack = {
-            navController.popBackStack()
-        },
-        onClickCart = {
-            // TODO : Cart 로 이동
-        }
+        state = state,
+        onEvent = viewModel::setEvent
     )
 }

--- a/feature/search/src/main/java/com/chan/search/ui/composables/SearchScreenContent.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/SearchScreenContent.kt
@@ -133,7 +133,7 @@ fun SearchScreenContent(
         }
 
         AnimatedVisibility(
-            visible = state.showFilter,
+            visible = state.filter.showFilter,
             enter = fadeIn(animationSpec = tween(300)),
             exit = fadeOut(animationSpec = tween(300))
         ) {
@@ -144,13 +144,13 @@ fun SearchScreenContent(
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
-                        onClick = { onEvent(SearchContract.Event.OnUpdateFilterClick) }
+                        onClick = { onEvent(SearchContract.Event.Filter.OnFilterClick) }
                     )
             )
         }
 
         AnimatedVisibility(
-            visible = state.showFilter,
+            visible = state.filter.showFilter,
             enter = slideInHorizontally(
                 initialOffsetX = { it },
                 animationSpec = tween(300)

--- a/feature/search/src/main/java/com/chan/search/ui/composables/SearchScreenContent.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/SearchScreenContent.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import com.chan.android.model.ProductModel
 import com.chan.android.ui.theme.Black
 import com.chan.android.ui.theme.Spacing
 import com.chan.android.ui.theme.White
@@ -41,53 +40,21 @@ import com.chan.android.ui.theme.dividerColor
 import com.chan.navigation.Routes
 import com.chan.search.R
 import com.chan.search.ui.composables.result.SearchResultScreen
-import com.chan.search.ui.model.SearchHistoryModel
-import com.chan.search.ui.model.SearchResultModel
-import com.chan.search.ui.model.TrendingSearchModel
-import com.chan.search.ui.model.filter.DeliveryOption
-import com.chan.search.ui.model.filter.FilterCategoriesModel
+import com.chan.search.ui.contract.SearchContract
 
 @Composable
 fun SearchScreenContent(
     navController: NavHostController,
-    search: String,
-    recentSearches: List<SearchHistoryModel>,
-    recommendedKeywords: List<String>,
-    trendingSearches: List<TrendingSearchModel>,
-    searchResults: List<SearchResultModel>,
-    currentTime: String,
-    showSearchResult: Boolean,
-    searchResultProducts: List<ProductModel>,
-    showFilter: Boolean,
-    selectedDeliveryOption: DeliveryOption?,
-    categoryFilters: List<FilterCategoriesModel>,
-    expandedCategoryName: String?,
-    selectedSubCategories: Set<String>,
-    isCategorySectionExpanded: Boolean,
-    filteredProductCount: Int,
-    onSearchChanged: (String) -> Unit,
-    onClearSearch: () -> Unit,
-    onSearchClick: (String) -> Unit,
-    onSearchTextFocus: () -> Unit,
-    onRemoveSearchKeyword: (String) -> Unit,
-    onClearAllRecentSearches: () -> Unit,
-    onSearchResultItemClick: (String) -> Unit,
-    onClickBack: () -> Unit,
-    onClickCart: () -> Unit,
-    onFilterClear: () -> Unit,
-    onUpdateFilterClick: () -> Unit,
-    onDeliveryOptionClick: (DeliveryOption) -> Unit,
-    onCategoryHeaderClick: (String) -> Unit,
-    onSubCategoryClick: (String) -> Unit,
-    onFilterCategoryClick: () -> Unit,
+    state: SearchContract.State,
+    onEvent: (SearchContract.Event) -> Unit
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
             containerColor = White,
             topBar = {
                 SearchTopAppBar(
-                    onClickBack = onClickBack,
-                    onClickCart = onClickCart
+                    onClickBack = { navController.popBackStack() },
+                    onClickCart = { }
                 )
             },
         ) { paddingValues ->
@@ -98,65 +65,75 @@ fun SearchScreenContent(
             ) {
 
                 SearchTextField(
-                    search = search,
-                    onSearchChanged = onSearchChanged,
-                    onClearSearch = onClearSearch,
-                    onSearchClick = {
-                        onSearchClick(it)
-                    },
-                    onSearchTextFocus = {
-                        onSearchTextFocus()
-                    },
+                    search = state.search,
+                    onSearchChanged = { onEvent(SearchContract.Event.OnSearchChanged(it)) },
+                    onClearSearch = { onEvent(SearchContract.Event.OnClickClearSearch) },
+                    onSearchClick = { onEvent(SearchContract.Event.OnAddSearchKeyword(it)) },
+                    onSearchTextFocus = { onEvent(SearchContract.Event.OnSearchTextFocus) },
                     modifier = Modifier.padding(Spacing.spacing4)
                 )
                 HorizontalDivider(color = dividerColor, thickness = 1.dp)
 
-                if (!showSearchResult) {
-                    if (search.isBlank()) {
-                        if (recentSearches.isNotEmpty()) {
+                when {
+                    state.showSearchResult -> {
+                        if (state.searchResultProducts.isEmpty()) {
+                            Text(text = stringResource(R.string.search_empty_product))
+                        } else {
+                            Box(modifier = Modifier.weight(1f)) {
+                                SearchResultScreen(
+                                    state = state,
+                                    onEvent = onEvent,
+                                    onProductClick = { productId ->
+                                        navController.navigate(
+                                            Routes.PRODUCT_DETAIL.productDetailRoute(productId)
+                                        )
+                                    }
+                                )
+                            }
+                        }
+                    }
+
+                    state.search.isBlank() -> {
+                        if (state.recentSearches.isNotEmpty()) {
                             RecentSearchList(
-                                recentSearches = recentSearches,
-                                onRemoveSearch = onRemoveSearchKeyword,
-                                onClearAllRecentSearches = onClearAllRecentSearches,
-                                onSearchClick = {
-                                    onSearchClick(it)
+                                recentSearches = state.recentSearches,
+                                onRemoveSearch = {
+                                    onEvent(
+                                        SearchContract.Event.OnRemoveSearchKeyword(
+                                            it
+                                        )
+                                    )
                                 },
+                                onClearAllRecentSearches = { onEvent(SearchContract.Event.OnClearAllRecentSearches) },
+                                onSearchClick = { onEvent(SearchContract.Event.OnAddSearchKeyword(it)) },
                             )
                         }
-                        RecommendedKeywordList(recommendedKeywords = recommendedKeywords)
+                        RecommendedKeywordList(recommendedKeywords = state.recommendedKeywords)
                         TrendingSearchList(
-                            trendingSearches = trendingSearches,
-                            currentTime = currentTime
-                        )
-                    } else {
-                        SearchResultList(
-                            results = searchResults,
-                            searchQuery = search,
-                            onSearchResultItemClick = onSearchResultItemClick
+                            trendingSearches = state.trendingSearches,
+                            currentTime = state.currentTime
                         )
                     }
-                } else {
-                    if (searchResultProducts.isEmpty()) {
-                        Text(text = stringResource(R.string.search_empty_product))
-                    } else {
-                        Box(modifier = Modifier.weight(1f)) {
-                            SearchResultScreen(
-                                products = searchResultProducts,
-                                onNavigateToFilter = onUpdateFilterClick,
-                                onProductClick = { productId ->
-                                    navController.navigate(
-                                        Routes.PRODUCT_DETAIL.productDetailRoute(productId)
+
+                    else -> {
+                        SearchResultList(
+                            results = state.searchResults,
+                            searchQuery = state.search,
+                            onSearchResultItemClick = {
+                                onEvent(
+                                    SearchContract.Event.OnClickSearchProduct(
+                                        it
                                     )
-                                }
-                            )
-                        }
+                                )
+                            }
+                        )
                     }
                 }
             }
         }
 
         AnimatedVisibility(
-            visible = showFilter,
+            visible = state.showFilter,
             enter = fadeIn(animationSpec = tween(300)),
             exit = fadeOut(animationSpec = tween(300))
         ) {
@@ -167,13 +144,13 @@ fun SearchScreenContent(
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
-                        onClick = onUpdateFilterClick
+                        onClick = { onEvent(SearchContract.Event.OnUpdateFilterClick) }
                     )
             )
         }
 
         AnimatedVisibility(
-            visible = showFilter,
+            visible = state.showFilter,
             enter = slideInHorizontally(
                 initialOffsetX = { it },
                 animationSpec = tween(300)
@@ -188,18 +165,8 @@ fun SearchScreenContent(
                 contentAlignment = Alignment.CenterEnd
             ) {
                 SearchFilterScreen(
-                    selectedDeliveryOption = selectedDeliveryOption,
-                    categoryFilters = categoryFilters,
-                    expandedCategoryName = expandedCategoryName,
-                    selectedSubCategories = selectedSubCategories,
-                    isCategorySectionExpanded = isCategorySectionExpanded,
-                    filteredProductCount = filteredProductCount,
-                    onClose = onUpdateFilterClick,
-                    onDeliveryOptionClick = onDeliveryOptionClick,
-                    onCategoryHeaderClick = onCategoryHeaderClick,
-                    onSubCategoryClick = onSubCategoryClick,
-                    onFilterCategoryClick = onFilterCategoryClick,
-                    onFilterClear = onFilterClear,
+                    state = state,
+                    onEvent = onEvent,
                     modifier = Modifier
                         .fillMaxWidth(0.8f)
                         .fillMaxHeight()

--- a/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreen.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreen.kt
@@ -11,14 +11,8 @@ fun SearchResultScreen(
 ) {
 
     SearchResultScreenContent(
-        products = state.searchResultProducts,
-        filters = state.filter.filterChips,
-        onToggleFilter = {
-            onEvent(SearchContract.Event.Filter.OnFilterChipClicked(it))
-        },
-        onFilterClick = {
-            onEvent(SearchContract.Event.Filter.OnFilterClick)
-        },
+        state = state,
+        onEvent = onEvent,
         onProductClick = { productId ->
             onProductClick(productId)
         }

--- a/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreen.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreen.kt
@@ -12,12 +12,12 @@ fun SearchResultScreen(
 
     SearchResultScreenContent(
         products = state.searchResultProducts,
-        filters = state.filterChips,
+        filters = state.filter.filterChips,
         onToggleFilter = {
-            onEvent(SearchContract.Event.OnFilterChipClicked(it))
+            onEvent(SearchContract.Event.Filter.OnFilterChipClicked(it))
         },
-        onNavigateToFilter = {
-            onEvent(SearchContract.Event.OnUpdateFilterClick)
+        onFilterClick = {
+            onEvent(SearchContract.Event.Filter.OnFilterClick)
         },
         onProductClick = { productId ->
             onProductClick(productId)

--- a/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreen.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreen.kt
@@ -1,31 +1,23 @@
 package com.chan.search.ui.composables.result
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.chan.android.model.ProductModel
 import com.chan.search.ui.contract.SearchContract
-import com.chan.search.ui.viewmodel.SearchViewModel
 
 @Composable
 fun SearchResultScreen(
-    viewModel: SearchViewModel = hiltViewModel(),
-    products: List<ProductModel>,
-    onNavigateToFilter: () -> Unit,
+    state: SearchContract.State,
+    onEvent: (SearchContract.Event) -> Unit,
     onProductClick: (String) -> Unit
 ) {
-    val state by viewModel.viewState.collectAsState()
-
 
     SearchResultScreenContent(
-        products = products,
+        products = state.searchResultProducts,
         filters = state.filterChips,
         onToggleFilter = {
-            viewModel.setEvent(SearchContract.Event.OnFilterChipClicked(it))
+            onEvent(SearchContract.Event.OnFilterChipClicked(it))
         },
         onNavigateToFilter = {
-            onNavigateToFilter()
+            onEvent(SearchContract.Event.OnUpdateFilterClick)
         },
         onProductClick = { productId ->
             onProductClick(productId)

--- a/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreenContent.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreenContent.kt
@@ -61,7 +61,7 @@ fun SearchResultScreenContent(
     products: List<ProductModel>,
     filters: List<SearchResultFilterChipModel>,
     onToggleFilter: (SearchResultFilterChipModel) -> Unit,
-    onNavigateToFilter: () -> Unit,
+    onFilterClick: () -> Unit,
     onProductClick: (String) -> Unit
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
@@ -95,7 +95,7 @@ fun SearchResultScreenContent(
                     FilterChipsRow(
                         filters = filters,
                         onToggleFilter = onToggleFilter,
-                        onNavigateToFilter = onNavigateToFilter,
+                        onFilterClick = onFilterClick,
                     )
                     HorizontalDivider(color = dividerColor, thickness = 1.dp)
                 }
@@ -224,7 +224,7 @@ private fun SearchResultTabRow(
 private fun FilterChipsRow(
     filters: List<SearchResultFilterChipModel>,
     onToggleFilter: (SearchResultFilterChipModel) -> Unit,
-    onNavigateToFilter: () -> Unit,
+    onFilterClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxWidth()) {
@@ -239,7 +239,7 @@ private fun FilterChipsRow(
                 FilterChip(
                     filter = filter,
                     onToggleFilter = onToggleFilter,
-                    onNavigateToFilter = onNavigateToFilter,
+                    onFilterClick = onFilterClick,
                 )
             }
         }
@@ -250,7 +250,7 @@ private fun FilterChipsRow(
 private fun FilterChip(
     filter: SearchResultFilterChipModel,
     onToggleFilter: (SearchResultFilterChipModel) -> Unit,
-    onNavigateToFilter: () -> Unit,
+    onFilterClick: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val containerColor = if (filter.isSelected) Color.Black else Color.White
@@ -267,7 +267,7 @@ private fun FilterChip(
                 onClick = {
                     when (filter.chipType) {
                         FilterChipType.TOGGLE -> onToggleFilter(filter)
-                        FilterChipType.DROP_DOWN -> onNavigateToFilter()
+                        FilterChipType.DROP_DOWN -> onFilterClick()
                     }
                 }
             )

--- a/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreenContent.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/result/SearchResultScreenContent.kt
@@ -1,75 +1,40 @@
 package com.chan.search.ui.composables.result
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import com.chan.android.ProductCard
 import com.chan.android.model.ProductModel
-import com.chan.android.ui.theme.LightGray
-import com.chan.android.ui.theme.Radius
 import com.chan.android.ui.theme.Spacing
 import com.chan.android.ui.theme.White
-import com.chan.android.ui.theme.appTypography
 import com.chan.android.ui.theme.dividerColor
-import com.chan.search.ui.model.FilterChipType
-import com.chan.search.ui.model.SearchResultFilterChipModel
+import com.chan.search.ui.composables.result.composables.FilterChipRow
+import com.chan.search.ui.composables.result.composables.TabRow
+import com.chan.search.ui.composables.result.composables.productGrid
+import com.chan.search.ui.contract.SearchContract
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SearchResultScreenContent(
-    products: List<ProductModel>,
-    filters: List<SearchResultFilterChipModel>,
-    onToggleFilter: (SearchResultFilterChipModel) -> Unit,
-    onFilterClick: () -> Unit,
+    state: SearchContract.State,
+    onEvent: (SearchContract.Event) -> Unit,
     onProductClick: (String) -> Unit
 ) {
-    var selectedTabIndex by remember { mutableStateOf(0) }
-    val tabs = listOf("상품", "후기", "콘텐츠")
     val lazyListState = rememberLazyListState()
 
-    LaunchedEffect(products) {
-        if (products.isNotEmpty()) {
+    LaunchedEffect(state.searchResultProducts) {
+        if (state.searchResultProducts.isNotEmpty()) {
             lazyListState.scrollToItem(0)
         }
     }
@@ -79,10 +44,12 @@ fun SearchResultScreenContent(
         state = lazyListState
     ) {
         item {
-            SearchResultTabRow(
-                tabs = tabs,
-                selectedTabIndex = selectedTabIndex,
-                onTabSelected = { selectedTabIndex = it }
+            TabRow(
+                tabs = state.resultTabRow.tabs,
+                selectedTabIndex = state.resultTabRow.resultSelectedTabIndex,
+                onTabSelected = { selectedTabIndex ->
+                    onEvent(SearchContract.Event.TabRow.OnResultTabSelected(selectedTabIndex))
+                }
             )
         }
 
@@ -92,216 +59,55 @@ fun SearchResultScreenContent(
                 color = White
             ) {
                 Column {
-                    FilterChipsRow(
-                        filters = filters,
-                        onToggleFilter = onToggleFilter,
-                        onFilterClick = onFilterClick,
+                    FilterChipRow(
+                        filters = state.filter.filterChips,
+                        onToggleFilter = {
+                            onEvent(
+                                SearchContract.Event.Filter.OnFilterChipClicked(
+                                    it
+                                )
+                            )
+                        },
+                        onFilterClick = { onEvent(SearchContract.Event.Filter.OnFilterClick) },
                     )
                     HorizontalDivider(color = dividerColor, thickness = 1.dp)
                 }
             }
         }
 
-        when (selectedTabIndex) {
+        when (state.resultTabRow.resultSelectedTabIndex) {
             0 -> { // 상품
-                item {
-                    SearchResultListHeader(products)
-                }
-                productGrid(
-                    products = products,
+                productTabContent(
+                    products = state.searchResultProducts,
                     onProductClick = onProductClick
                 )
             }
 
-            1 -> { // 후기
-                item { Text("후기 탭 내용") }
-            }
-
-            2 -> { // 콘텐츠
-                item { Text("콘텐츠 탭 내용") }
-            }
+            1 -> reviewTabContent()
+            2 -> contentTabContent()
         }
     }
 }
 
-private fun LazyListScope.productGrid(
+private fun LazyListScope.productTabContent(
     products: List<ProductModel>,
     onProductClick: (String) -> Unit
 ) {
-    val chunkedProducts = products.chunked(2)
-    items(
-        items = chunkedProducts,
-        key = { row -> row.joinToString { it.productId } }
-    ) { productRow ->
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(Spacing.spacing2)
-        ) {
-            productRow.forEach { product ->
-                Box(modifier = Modifier.weight(1f)) {
-                    ProductCard(
-                        product = product,
-                        onClick = { onProductClick(product.productId) },
-                        onLikeClick = {},
-                        onCartClick = {}
-                    )
-                }
-            }
-            if (productRow.size == 1) {
-                Spacer(modifier = Modifier.weight(1f))
-            }
-        }
+    item {
+        SearchResultListHeader(products)
     }
+    productGrid(
+        products = products,
+        onProductClick = onProductClick
+    )
 }
 
-@Composable
-fun CustomTab(
-    title: String,
-    isSelected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    var textWidth by remember { mutableStateOf(0.dp) }
-    val density = LocalDensity.current
-
-    Box(
-        modifier = modifier
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = onClick
-            )
-            .padding(horizontal = Spacing.spacing4)
-    ) {
-        Text(
-            text = title,
-            color = if (isSelected) Color.Black else Color.Gray,
-            style = MaterialTheme.appTypography.tab.copy(
-                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
-            ),
-            onTextLayout = { textLayoutResult ->
-                textWidth = with(density) { textLayoutResult.size.width.toDp() }
-            },
-            modifier = Modifier
-                .padding(vertical = Spacing.spacing4)
-                .align(Alignment.Center)
-        )
-
-        Box(
-            modifier = Modifier
-                .width(textWidth)
-                .height(2.dp)
-                .background(if (isSelected) Color.Black else Color.Transparent)
-                .align(Alignment.BottomCenter)
-        )
-    }
+private fun LazyListScope.reviewTabContent() {
+    item { Text("후기 탭 내용") }
 }
 
-@Composable
-private fun SearchResultTabRow(
-    tabs: List<String>,
-    selectedTabIndex: Int,
-    onTabSelected: (Int) -> Unit
-) {
-    Column(modifier = Modifier.background(Color.White)) {
-        Row(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            tabs.forEachIndexed { index, title ->
-                CustomTab(
-                    title = title,
-                    isSelected = index == selectedTabIndex,
-                    onClick = { onTabSelected(index) },
-                    modifier = Modifier.weight(1f)
-                )
-            }
-        }
-        HorizontalDivider(color = dividerColor, thickness = 1.dp)
-    }
-}
-
-@Composable
-private fun FilterChipsRow(
-    filters: List<SearchResultFilterChipModel>,
-    onToggleFilter: (SearchResultFilterChipModel) -> Unit,
-    onFilterClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier
-                .horizontalScroll(rememberScrollState())
-                .padding(horizontal = Spacing.spacing4, vertical = Spacing.spacing2),
-            horizontalArrangement = Arrangement.spacedBy(Spacing.spacing2),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            filters.forEach { filter ->
-                FilterChip(
-                    filter = filter,
-                    onToggleFilter = onToggleFilter,
-                    onFilterClick = onFilterClick,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun FilterChip(
-    filter: SearchResultFilterChipModel,
-    onToggleFilter: (SearchResultFilterChipModel) -> Unit,
-    onFilterClick: () -> Unit,
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val containerColor = if (filter.isSelected) Color.Black else Color.White
-    val textColor = if (filter.isSelected) Color.White else Color.DarkGray
-
-    Box(
-        modifier = Modifier
-            .background(color = containerColor, shape = RoundedCornerShape(Radius.radius6))
-            .clip(RoundedCornerShape(Radius.radius6))
-            .border(width = 1.dp, color = LightGray, shape = RoundedCornerShape(Radius.radius6))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                onClick = {
-                    when (filter.chipType) {
-                        FilterChipType.TOGGLE -> onToggleFilter(filter)
-                        FilterChipType.DROP_DOWN -> onFilterClick()
-                    }
-                }
-            )
-            .padding(horizontal = Spacing.spacing3, vertical = Spacing.spacing2)
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            when (filter.chipType) {
-                FilterChipType.TOGGLE -> {
-                    AsyncImage(
-                        model = filter.image,
-                        contentDescription = filter.text,
-                        modifier = Modifier
-                            .size(Spacing.spacing5)
-                            .padding(end = Spacing.spacing1)
-                    )
-                    Text(text = filter.text, color = textColor)
-                }
-
-                FilterChipType.DROP_DOWN -> {
-                    Text(
-                        text = filter.text,
-                        color = textColor,
-                        modifier = Modifier.padding(end = Spacing.spacing1)
-                    )
-                    Icon(
-                        imageVector = Icons.Default.ArrowDropDown,
-                        contentDescription = "Dropdown",
-                        tint = textColor,
-                        modifier = Modifier.size(Spacing.spacing4)
-                    )
-                }
-            }
-        }
-    }
+private fun LazyListScope.contentTabContent() {
+    item { Text("콘텐츠 탭 내용") }
 }
 
 @Composable

--- a/feature/search/src/main/java/com/chan/search/ui/composables/result/composables/FilterChipRow.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/result/composables/FilterChipRow.kt
@@ -1,0 +1,129 @@
+package com.chan.search.ui.composables.result.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.chan.android.ui.theme.Black
+import com.chan.android.ui.theme.DarkGray
+import com.chan.android.ui.theme.LightGray
+import com.chan.android.ui.theme.Radius
+import com.chan.android.ui.theme.Spacing
+import com.chan.android.ui.theme.White
+import com.chan.search.ui.model.FilterChipType
+import com.chan.search.ui.model.SearchResultFilterChipModel
+import kotlin.collections.forEach
+
+@Composable
+fun FilterChipRow(
+    filters: List<SearchResultFilterChipModel>,
+    onToggleFilter: (SearchResultFilterChipModel) -> Unit,
+    onFilterClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.spacing4, vertical = Spacing.spacing2),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.spacing2),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            filters.forEach { filter ->
+                FilterChip(
+                    filter = filter,
+                    onToggleFilter = onToggleFilter,
+                    onFilterClick = onFilterClick,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterChip(
+    filter: SearchResultFilterChipModel,
+    onToggleFilter: (SearchResultFilterChipModel) -> Unit,
+    onFilterClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val chipCornerShape = RoundedCornerShape(Radius.radius6)
+    val (containerColor, textColor) = if (filter.isSelected) {
+        Black to Color.White
+    } else {
+        White to DarkGray
+    }
+
+    Box(
+        modifier = Modifier
+            .background(color = containerColor, shape = chipCornerShape)
+            .clip(chipCornerShape)
+            .border(width = 1.dp, color = LightGray, shape = chipCornerShape)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = {
+                    when (filter.chipType) {
+                        FilterChipType.TOGGLE -> onToggleFilter(filter)
+                        FilterChipType.DROP_DOWN -> onFilterClick()
+                    }
+                }
+            )
+            .padding(horizontal = Spacing.spacing3, vertical = Spacing.spacing2)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            when (filter.chipType) {
+                FilterChipType.TOGGLE -> ToggleChipContent(filter, textColor)
+                FilterChipType.DROP_DOWN -> DropDownChipContent(filter, textColor)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToggleChipContent(filter: SearchResultFilterChipModel, textColor: Color) {
+    AsyncImage(
+        model = filter.image,
+        contentDescription = filter.text,
+        modifier = Modifier
+            .size(Spacing.spacing5)
+            .padding(end = Spacing.spacing1)
+    )
+    Text(text = filter.text, color = textColor)
+}
+
+@Composable
+private fun DropDownChipContent(filter: SearchResultFilterChipModel, textColor: Color) {
+    Text(
+        text = filter.text,
+        color = textColor,
+        modifier = Modifier.padding(end = Spacing.spacing1)
+    )
+    Icon(
+        imageVector = Icons.Default.ArrowDropDown,
+        contentDescription = "Dropdown",
+        tint = textColor,
+        modifier = Modifier.size(Spacing.spacing4)
+    )
+}

--- a/feature/search/src/main/java/com/chan/search/ui/composables/result/composables/ProductGridView.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/result/composables/ProductGridView.kt
@@ -1,0 +1,43 @@
+package com.chan.search.ui.composables.result.composables
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.ui.Modifier
+import com.chan.android.ProductCard
+import com.chan.android.model.ProductModel
+import com.chan.android.ui.theme.Spacing
+
+fun LazyListScope.productGrid(
+    products: List<ProductModel>,
+    onProductClick: (String) -> Unit
+) {
+    val chunkedProducts = products.chunked(2)
+    items(
+        items = chunkedProducts,
+        key = { row -> row.joinToString { it.productId } }
+    ) { productRow ->
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.spacing2)
+        ) {
+            productRow.forEach { product ->
+                Box(modifier = Modifier.weight(1f)) {
+                    ProductCard(
+                        product = product,
+                        onClick = { onProductClick(product.productId) },
+                        onLikeClick = {},
+                        onCartClick = {}
+                    )
+                }
+            }
+            if (productRow.size == 1) {
+                Spacer(modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}

--- a/feature/search/src/main/java/com/chan/search/ui/composables/result/composables/TabRow.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/composables/result/composables/TabRow.kt
@@ -1,0 +1,97 @@
+package com.chan.search.ui.composables.result.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.chan.android.ui.theme.Spacing
+import com.chan.android.ui.theme.appTypography
+import com.chan.android.ui.theme.dividerColor
+import com.chan.search.ui.model.result.SearchResultTab
+
+@Composable
+fun TabRow(
+    tabs: List<SearchResultTab>,
+    selectedTabIndex: Int,
+    onTabSelected: (Int) -> Unit
+) {
+    Column(modifier = Modifier.background(Color.White)) {
+        Row(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            tabs.forEachIndexed { index, tab ->
+                CustomTab(
+                    title = tab.title,
+                    isSelected = index == selectedTabIndex,
+                    onClick = { onTabSelected(index) },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+        HorizontalDivider(color = dividerColor, thickness = 1.dp)
+    }
+}
+
+
+@Composable
+private fun CustomTab(
+    title: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var textWidth by remember { mutableStateOf(0.dp) }
+    val density = LocalDensity.current
+
+    Box(
+        modifier = modifier
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick
+            )
+            .padding(horizontal = Spacing.spacing4)
+    ) {
+        Text(
+            text = title,
+            color = if (isSelected) Color.Black else Color.Gray,
+            style = MaterialTheme.appTypography.tab.copy(
+                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
+            ),
+            onTextLayout = { textLayoutResult ->
+                textWidth = with(density) { textLayoutResult.size.width.toDp() }
+            },
+            modifier = Modifier
+                .padding(vertical = Spacing.spacing4)
+                .align(Alignment.Center)
+        )
+
+        Box(
+            modifier = Modifier
+                .width(textWidth)
+                .height(2.dp)
+                .background(if (isSelected) Color.Black else Color.Transparent)
+                .align(Alignment.BottomCenter)
+        )
+    }
+}

--- a/feature/search/src/main/java/com/chan/search/ui/contract/SearchContract.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/contract/SearchContract.kt
@@ -11,6 +11,7 @@ import com.chan.search.ui.model.SearchResultModel
 import com.chan.search.ui.model.TrendingSearchModel
 import com.chan.search.ui.model.filter.DeliveryOption
 import com.chan.search.ui.model.filter.FilterCategoriesModel
+import com.chan.search.ui.model.result.SearchResultTab
 
 class SearchContract {
 
@@ -24,7 +25,6 @@ class SearchContract {
         data class OnRemoveSearchKeyword(val search: String) : Event()
         object OnClearAllRecentSearches : Event()
 
-
         sealed class Filter : Event() {
             data class OnDeliveryOptionChanged(val option: DeliveryOption) : Filter()
             data class OnCategoryHeaderClick(val categoryName: String) : Filter()
@@ -33,6 +33,10 @@ class SearchContract {
             object OnCategoryClick : Filter()
             object OnFilterClick : Filter()
             object OnClear : Filter()
+        }
+
+        sealed class TabRow: Event() {
+            data class OnResultTabSelected(val index: Int): Event()
         }
     }
 
@@ -50,9 +54,16 @@ class SearchContract {
         val currentTime: String = "",
         val showSearchResult: Boolean = false,
 
-        val filter: FilterState = FilterState()
+        val filter: FilterState = FilterState(),
+        val resultTabRow: TabRow = TabRow()
+
 
     ) : ViewState
+
+    data class TabRow(
+        val resultSelectedTabIndex : Int = 0,
+        val tabs: List<SearchResultTab> = SearchResultTab.allTabs
+    )
 
     data class FilterState (
         val showFilter: Boolean = false,

--- a/feature/search/src/main/java/com/chan/search/ui/contract/SearchContract.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/contract/SearchContract.kt
@@ -24,14 +24,16 @@ class SearchContract {
         data class OnRemoveSearchKeyword(val search: String) : Event()
         object OnClearAllRecentSearches : Event()
 
-        object OnUpdateFilterClick : Event()
-        object OnFilterClear : Event()
 
-        data class OnFilterChipClicked(val chip: SearchResultFilterChipModel) : Event()
-        data class OnDeliveryOptionChanged(val option: DeliveryOption) : Event()
-        data class OnCategoryHeaderClick(val categoryName: String) : Event()
-        data class OnSubCategoryClick(val subCategoryName: String) : Event()
-        object OnFilterCategoryClick : Event()
+        sealed class Filter : Event() {
+            data class OnDeliveryOptionChanged(val option: DeliveryOption) : Filter()
+            data class OnCategoryHeaderClick(val categoryName: String) : Filter()
+            data class OnSubCategoryClick(val subCategoryName: String) : Filter()
+            data class OnFilterChipClicked(val chip: SearchResultFilterChipModel) : Filter()
+            object OnCategoryClick : Filter()
+            object OnFilterClick : Filter()
+            object OnClear : Filter()
+        }
     }
 
     data class State(
@@ -47,17 +49,21 @@ class SearchContract {
         val searchResultProducts: List<ProductModel> = emptyList(),
         val currentTime: String = "",
         val showSearchResult: Boolean = false,
-        val showFilter: Boolean = false,
 
+        val filter: FilterState = FilterState()
+
+    ) : ViewState
+
+    data class FilterState (
+        val showFilter: Boolean = false,
         val selectedDeliveryOption: DeliveryOption? = null,
         val filterChips: List<SearchResultFilterChipModel> = emptyList(),
-
         val categoryFilters: List<FilterCategoriesModel> = emptyList(),
         val expandedCategoryName: String? = null,
         val selectedSubCategories: Set<String> = emptySet(),
         val isCategorySectionExpanded: Boolean = false,
         val filteredProductCount: Int = 0
-    ) : ViewState
+    )
 
     sealed class Effect : ViewEffect {
         data class ShowError(val message: String) : Effect()

--- a/feature/search/src/main/java/com/chan/search/ui/mappers/CategoryFilterUiMapper.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/mappers/CategoryFilterUiMapper.kt
@@ -16,3 +16,4 @@ fun FilterCategoriesVO.toUiModel(): FilterCategoriesModel =
         }
     )
 
+

--- a/feature/search/src/main/java/com/chan/search/ui/model/result/SearchResultTab.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/model/result/SearchResultTab.kt
@@ -1,0 +1,11 @@
+package com.chan.search.ui.model.result
+
+sealed class SearchResultTab(val title: String, val index: Int) {
+    object Product: SearchResultTab("상품", 0)
+    object Review: SearchResultTab("후기", 1)
+    object Content: SearchResultTab("콘텐츠", 2)
+
+    companion object {
+        val allTabs: List<SearchResultTab> = listOf(Product, Review, Content)
+    }
+}

--- a/feature/search/src/main/java/com/chan/search/ui/viewmodel/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/chan/search/ui/viewmodel/SearchViewModel.kt
@@ -128,6 +128,10 @@ class SearchViewModel @Inject constructor(
                     )
                 )
             }
+
+            is SearchContract.Event.TabRow.OnResultTabSelected -> {
+                setState { copy(resultTabRow = resultTabRow.copy(resultSelectedTabIndex = event.index)) }
+            }
         }
     }
 


### PR DESCRIPTION
### **📌 Issue**
- #47  

### **🔖 요약**
1. Screen/ScreenContent, SearchResultScrren/ResultContent 구조 개선
2. SearchContract filter 관련 State, Event 분리

### **🛠 작업 내용**
1. 기존 파라미터 세분화를 통한 전달로 방대한 파라미터 및 유지보수 문제 존재 > state, event 단일 전달로 방대한 파라미터 구조 개선
2. SearchContract filter 관련하여 State와 Event를 분리함으로서 책임 분리 및 유지보수 용이

### **❗️ 참고 사항**
- [ ] SearchResultViewModel을 통해 책임 분리 예정
- 검색 결과 및 필터링 로직 별도로 분리
