### PR TITLE
refactor#52 장바구니 리팩토링 (RoomDB > protoDataStore)

### DIFF
--- a/feature/cart/src/main/java/com/chan/cart/data/CartRepositoryImpl.kt
+++ b/feature/cart/src/main/java/com/chan/cart/data/CartRepositoryImpl.kt
@@ -1,0 +1,128 @@
+package com.chan.cart.data
+
+import androidx.datastore.core.DataStore
+import com.chan.cart.data.mapper.toProductsVO
+import com.chan.cart.domain.CartRepository
+import com.chan.cart.proto.Cart
+import com.chan.cart.proto.CartItem
+import com.chan.database.dao.ProductsDao
+import com.chan.domain.ProductsVO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CartRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<Cart>,
+    private val productsDao: ProductsDao
+) : CartRepository {
+
+    override suspend fun getProductInfo(productId: String): ProductsVO {
+        return productsDao.getProductsByProductId(productId)?.toProductsVO()
+            ?: throw NoSuchElementException("Product not found with id: $productId")
+    }
+
+    override fun getCartItems(): Flow<List<CartItem>> {
+        return dataStore.data.map { it.itemsList }
+    }
+
+    override suspend fun addProductToCart(productId: String) {
+        dataStore.updateData { cart ->
+            val existingItem = cart.itemsList.find { it.productId == productId }
+
+            if (existingItem != null) {
+                val updatedItems = cart.itemsList.map {
+                    if (it.productId == productId) {
+                        it.toBuilder().setQuantity(it.quantity + 1).build()
+                    } else {
+                        it
+                    }
+                }
+                cart.toBuilder().clearItems().addAllItems(updatedItems).build()
+            } else {
+                val productInfo = productsDao.getProductsByProductId(productId)
+                if (productInfo != null) {
+                    val newItem = CartItem.newBuilder()
+                        .setProductId(productId)
+                        .setProductName(productInfo.productName)
+                        .setImageUrl(productInfo.imageUrl)
+                        .setOriginPrice(productInfo.originalPrice)
+                        .setDiscountedPrice(productInfo.discountPrice)
+                        .setQuantity(1)
+                        .setIsSelected(true)
+                        .build()
+                    cart.toBuilder().addItems(newItem).build()
+                } else {
+                    cart
+                }
+            }
+        }
+    }
+
+    override suspend fun removeProductFromCart(productId: String) {
+        updateCartItems { items ->
+            items.filterNot { it.productId == productId }
+        }
+    }
+
+    override suspend fun updateProductSelected(productId: String, isSelected: Boolean) {
+        updateCartItems { items ->
+            items.map {
+                if (it.productId == productId) {
+                    it.toBuilder().setIsSelected(isSelected).build()
+                } else {
+                    it
+                }
+            }
+        }
+    }
+
+    override suspend fun increaseProductQuantity(productId: String) {
+        updateCartItems { items ->
+            items.map {
+                if (it.productId == productId) {
+                    it.toBuilder().setQuantity(it.quantity + 1).build()
+                } else {
+                    it
+                }
+            }
+        }
+    }
+
+    override suspend fun decreaseProductQuantity(productId: String) {
+        dataStore.updateData { cart ->
+            val targetItem = cart.itemsList.find { it.productId == productId } ?: return@updateData cart
+
+            val updatedItems = if (targetItem.quantity > 1) {
+                cart.itemsList.map {
+                    if (it.productId == productId) {
+                        it.toBuilder().setQuantity(it.quantity - 1).build()
+                    } else {
+                        it
+                    }
+                }
+            } else {
+                cart.itemsList.filterNot { it.productId == productId }
+            }
+            cart.toBuilder().clearItems().addAllItems(updatedItems).build()
+        }
+    }
+
+    override suspend fun updateAllProductsSelected(isSelected: Boolean) {
+        updateCartItems { items ->
+            items.map {
+                it.toBuilder().setIsSelected(isSelected).build()
+            }
+        }
+    }
+
+    private suspend fun updateCartItems(transform: (List<CartItem>) -> List<CartItem>) {
+        dataStore.updateData { cart ->
+            val originalItems = cart.itemsList
+            val updatedItems = transform(originalItems) // 로직 실행
+            cart.toBuilder().clearItems().addAllItems(updatedItems).build()
+        }
+    }
+
+}

--- a/feature/cart/src/main/java/com/chan/cart/data/datastore/CartDataStore.kt
+++ b/feature/cart/src/main/java/com/chan/cart/data/datastore/CartDataStore.kt
@@ -1,0 +1,11 @@
+package com.chan.cart.data.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStore
+import com.chan.cart.proto.Cart
+
+val Context.cartProtoDataStore: DataStore<Cart> by dataStore(
+    fileName = "cart.pb",
+    serializer = CartSerializer
+)

--- a/feature/cart/src/main/java/com/chan/cart/data/datastore/CartSerializer.kt
+++ b/feature/cart/src/main/java/com/chan/cart/data/datastore/CartSerializer.kt
@@ -1,0 +1,22 @@
+package com.chan.cart.data.datastore
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import com.chan.cart.proto.Cart
+import com.google.protobuf.InvalidProtocolBufferException
+import java.io.InputStream
+import java.io.OutputStream
+
+object CartSerializer : Serializer<Cart> {
+    override val defaultValue: Cart = Cart.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): Cart {
+        try {
+            return Cart.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+    }
+
+    override suspend fun writeTo(t: Cart, output: OutputStream) = t.writeTo(output)
+}

--- a/feature/cart/src/main/java/com/chan/cart/data/di/DataStoreModule.kt
+++ b/feature/cart/src/main/java/com/chan/cart/data/di/DataStoreModule.kt
@@ -1,0 +1,23 @@
+package com.chan.cart.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import com.chan.cart.data.datastore.cartProtoDataStore
+import com.chan.cart.proto.Cart
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+
+    @Singleton
+    @Provides
+    fun provideCartDataStore(@ApplicationContext context: Context): DataStore<Cart> {
+        return context.cartProtoDataStore
+    }
+}

--- a/feature/cart/src/main/java/com/chan/cart/domain/CartRepository.kt
+++ b/feature/cart/src/main/java/com/chan/cart/domain/CartRepository.kt
@@ -1,0 +1,47 @@
+package com.chan.cart.domain
+
+import com.chan.cart.proto.CartItem
+import com.chan.domain.ProductsVO
+import kotlinx.coroutines.flow.Flow
+
+interface CartRepository {
+    /**
+     * 장바구니 팝업 상품의 상세 정보 조회
+     */
+    suspend fun getProductInfo(productId: String): ProductsVO
+
+    /**
+     * 장바구니 상품 목록
+     */
+    fun getCartItems(): Flow<List<CartItem>>
+
+    /**
+     * 장바구니 상품 추가
+     */
+    suspend fun addProductToCart(productId: String)
+
+    /**
+     * 장바구니에서 특정 상품을 제거
+     */
+    suspend fun removeProductFromCart(productId: String)
+
+    /**
+     * 상품 선택 상태 업데이트
+     */
+    suspend fun updateProductSelected(productId: String, isSelected: Boolean)
+
+    /**
+     * 상품 수량 + 1
+     */
+    suspend fun increaseProductQuantity(productId: String)
+
+    /**
+     * 상품 수량 - 1
+     */
+    suspend fun decreaseProductQuantity(productId: String)
+
+    /**
+     * 상품 상태 전체 업데이트 (선택/해제)
+     */
+    suspend fun updateAllProductsSelected(isSelected: Boolean)
+}

--- a/feature/cart/src/main/java/com/chan/cart/ui/mapper/CartMapper.kt
+++ b/feature/cart/src/main/java/com/chan/cart/ui/mapper/CartMapper.kt
@@ -1,0 +1,24 @@
+package com.chan.cart.ui.mapper
+
+import com.chan.cart.model.CartInProductsModel
+import com.chan.cart.proto.CartItem
+
+fun CartItem.toDataStoreCartInProductsModel(): CartInProductsModel {
+    return CartInProductsModel(
+        productId = this.productId,
+        productName = this.productName,
+        imageUrl = this.imageUrl,
+        originalPrice = "%,d원".format(this.originPrice),
+        discountPrice = this.discountedPrice,
+        quantity = this.quantity,
+        isSelected = this.isSelected,
+        brandName = "",
+        discountPercent = "",
+        discountPriceLabel = "%,d원".format(this.discountedPrice),
+        tags = emptyList(),
+        reviewRating = "",
+        reviewCount = "",
+        categoryIds = emptyList()
+    )
+}
+

--- a/feature/cart/src/main/proto/cart.proto
+++ b/feature/cart/src/main/proto/cart.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option java_package = "com.chan.cart.proto";
+option java_multiple_files = true;
+
+message Cart {
+  repeated CartItem items = 1;
+}
+
+message CartItem {
+  string product_id = 1;
+  string product_name = 2;
+  string image_url = 3;
+  int32 origin_price = 4;
+  int32 discounted_price = 5;
+  int32 quantity = 6;
+  bool is_selected = 7;
+}

--- a/feature/home/src/main/java/com/chan/home/composables/home/HomeCategoryRanking.kt
+++ b/feature/home/src/main/java/com/chan/home/composables/home/HomeCategoryRanking.kt
@@ -94,8 +94,13 @@ fun HomeCategoryRanking(
                         onClick = { productId ->
                             onEvent(HomeContract.Event.OnProductClicked(productId = productId))
                         },
-                        onLikeClick = {},
-                        onCartClick = {}
+                        onLikeClick = {
+                                productId ->
+                            onEvent(HomeContract.Event.OnLikedClick(productId = productId))
+                        },
+                        onCartClick = { productId ->
+                            onEvent(HomeContract.Event.OnCartClicked(productId = productId))
+                        }
                     )
                 }
             }

--- a/feature/home/src/main/java/com/chan/home/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/chan/home/home/HomeContract.kt
@@ -3,17 +3,11 @@ package com.chan.home.home
 import com.chan.android.ViewEffect
 import com.chan.android.ViewEvent
 import com.chan.android.ViewState
-import com.chan.android.model.ProductModel
 import com.chan.android.model.ProductsModel
 import com.chan.home.model.HomeBannerModel
-import com.chan.home.model.HomePopularItemModel
-import com.chan.home.model.HomeRankingCategoryProductModel
 import com.chan.home.model.HomeRankingCategoryTabModel
 import com.chan.home.model.HomeSaleProductModel
 import com.chan.home.model.HomeTabItem
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flow
 
 class HomeContract {
     sealed class Event : ViewEvent {
@@ -26,6 +20,8 @@ class HomeContract {
         data class RankingTabClicked(val index: Int) : Event()
         data class RankingTabSelected(val categoryId: String) : Event()
         data class OnProductClicked(val productId: String) : Event()
+        data class OnLikedClick(val productId: String) : Event()
+        data class OnCartClicked(val productId: String) : Event()
     }
 
     data class State(
@@ -44,6 +40,8 @@ class HomeContract {
         data class ShowError(val message: String) : Effect()
         sealed class Navigation : ViewEffect {
             data class ToProductDetailRoute(val productId: String) : Effect()
+            data class ToCartPopupRoute(val productId: String) : Effect()
+            data class ToCartRoute(val productId: String) : Effect()
         }
     }
 }

--- a/feature/home/src/main/java/com/chan/home/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/chan/home/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import com.chan.home.domain.repository.HomeBannerRepository
 import com.chan.home.domain.repository.HomePopularItemRepository
 import com.chan.home.domain.repository.HomeSaleProductRepository
 import com.chan.home.domain.repository.RankingCategoryRepository
+import com.chan.home.home.HomeContract.Effect.Navigation.*
 import com.chan.home.mapper.toPresentation
 import com.chan.home.mapper.toProductsModel
 import com.chan.home.mapper.toRankingCategoryTabsModel
@@ -42,6 +43,8 @@ class HomeViewModel @Inject constructor(
             is HomeContract.Event.RankingTabSelected -> getRankingCategories(event.categoryId)
             HomeContract.Event.SaleProducts -> getSaleProducts()
             is HomeContract.Event.OnProductClicked -> productClicked(event.productId)
+            is HomeContract.Event.OnLikedClick -> setEffect { ToCartPopupRoute(event.productId) }
+            is HomeContract.Event.OnCartClicked -> setEffect { ToCartRoute(event.productId) }
         }
     }
 
@@ -50,7 +53,7 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun productClicked(productId: String) {
-        setEffect { HomeContract.Effect.Navigation.ToProductDetailRoute(productId) }
+        setEffect { ToProductDetailRoute(productId) }
     }
 
     private fun getBanners() {

--- a/feature/home/src/main/java/com/chan/home/navigation/HomeNavGraph.kt
+++ b/feature/home/src/main/java/com/chan/home/navigation/HomeNavGraph.kt
@@ -54,6 +54,16 @@ fun HomeRoute(navController: NavHostController) {
                     effect.message,
                     Toast.LENGTH_SHORT
                 ).show()
+                is HomeContract.Effect.Navigation.ToCartPopupRoute -> {
+                    navController.navigate(
+                        Routes.CART_POPUP.cartPopUpRoute(effect.productId)
+                    )
+                }
+                is HomeContract.Effect.Navigation.ToCartRoute -> {
+                    navController.navigate(
+                        Routes.CART.route
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
### **📌 Issue**
- #52  

### **🔖 요약**
1. 장바구니 클릭 및 Naivgate 처리 로직 추가
2. 장바구니 기존 RoomDB > protoDataStore 리팩토링

### **🛠 작업 내용**
1. `Contract`에 클릭, Navigate Event 및 Effect 추가하였습니다.
 - `ViewModel, NavGraph`에서 클릭 시 Effcet 처리, Navigate 로직을 추가하였습니다.
2. 장바구니 기존 RoomDB > protoDataStore로 리팩토링하였습니다.
 - cart.proto : 장바구니 스키마 정의
 - CartRepository/CartrepositoryImpl : 인터페이스 및 구현체 정의 (DataStore 사용)
 - CartSerializer : 직렬화 코드 작성
