### PR TITLE
feature#30 상품 리스트 무한스크롤 적용

### DIFF
--- a/core/database/src/main/java/com/chan/database/dao/ProductsDao.kt
+++ b/core/database/src/main/java/com/chan/database/dao/ProductsDao.kt
@@ -14,7 +14,7 @@ interface ProductsDao {
     @Query("SELECT * FROM products")
     suspend fun getAllProducts(): List<CommonProductEntity>
 
-    @Query("SELECT * FROM products")
+    @Query("SELECT * FROM products ORDER BY productId ASC")
     fun getAllProductsPaging(): PagingSource<Int, CommonProductEntity>
 
     /**

--- a/core/database/src/main/java/com/chan/database/dao/ProductsDao.kt
+++ b/core/database/src/main/java/com/chan/database/dao/ProductsDao.kt
@@ -1,5 +1,6 @@
 package com.chan.database.dao
 
+import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
@@ -12,6 +13,9 @@ interface ProductsDao {
 
     @Query("SELECT * FROM products")
     suspend fun getAllProducts(): List<CommonProductEntity>
+
+    @Query("SELECT * FROM products")
+    fun getAllProductsPaging(): PagingSource<Int, CommonProductEntity>
 
     /**
      * categoryId가 "c1, c2, c3"형태로 구성

--- a/feature/home/src/main/java/com/chan/home/composables/ranking/HomeRankingScreen.kt
+++ b/feature/home/src/main/java/com/chan/home/composables/ranking/HomeRankingScreen.kt
@@ -1,6 +1,5 @@
 package com.chan.home.composables.ranking
 
-import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,8 +12,11 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -22,9 +24,11 @@ import com.chan.android.model.ProductsModel
 import com.chan.android.ui.CommonProductsCard
 import com.chan.android.ui.theme.Spacing
 import com.chan.home.home.HomeContract
+import com.chan.home.home.HomeViewModel
 
 @Composable
 fun HomeRankingScreen(
+    viewModel: HomeViewModel = hiltViewModel(),
     state: HomeContract.State,
     onEvent: (HomeContract.Event) -> Unit
 ) {
@@ -33,7 +37,8 @@ fun HomeRankingScreen(
         onEvent(HomeContract.Event.HomeRankingEvent.RankingProductsLoad)
     }
 
-    val products = state.homeRankingState.rankingProducts?.collectAsLazyPagingItems()
+    val rankingProductsFlow by viewModel.rankingProducts.collectAsState()
+    val products = rankingProductsFlow?.collectAsLazyPagingItems()
 
     products?.let { lazyItems ->
         when (val refreshState = lazyItems.loadState.refresh) {
@@ -67,7 +72,10 @@ private fun SuccessProducts(
 }
 
 @Composable
-private fun ErrorProducts(refreshState: LoadState.Error, lazyItems: LazyPagingItems<ProductsModel>) {
+private fun ErrorProducts(
+    refreshState: LoadState.Error,
+    lazyItems: LazyPagingItems<ProductsModel>
+) {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text("데이터를 불러오지 못했습니다: ${refreshState.error.message}")

--- a/feature/home/src/main/java/com/chan/home/composables/ranking/HomeRankingScreen.kt
+++ b/feature/home/src/main/java/com/chan/home/composables/ranking/HomeRankingScreen.kt
@@ -1,0 +1,47 @@
+package com.chan.home.composables.ranking
+
+import android.util.Log
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.chan.android.ui.CommonProductsCard
+import com.chan.android.ui.theme.Spacing
+import com.chan.home.home.HomeContract
+
+@Composable
+fun HomeRankingScreen(
+    state: HomeContract.State,
+    onEvent: (HomeContract.Event) -> Unit
+) {
+
+    LaunchedEffect(Unit) {
+        Log.d("rankingInfo"," LaunchedEffect ")
+        onEvent(HomeContract.Event.HomeRankingEvent.RankingProductsLoad)
+    }
+
+    //무한 스크롤
+    state.homeRankingState.rankingProducts?.let { rankingProducts ->
+        val products = rankingProducts.collectAsLazyPagingItems()
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(Spacing.spacing2)
+        ) {
+            items(products.itemCount) { index ->
+                products[index]?.let { product ->
+                    CommonProductsCard(
+                        product = product,
+                        onClick = { onEvent(HomeContract.Event.OnProductClicked(it)) },
+                        onLikeClick = { onEvent(HomeContract.Event.OnLikedClick(it)) },
+                        onCartClick = { onEvent(HomeContract.Event.OnCartClicked(it)) }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/home/src/main/java/com/chan/home/composables/ranking/HomeRankingScreen.kt
+++ b/feature/home/src/main/java/com/chan/home/composables/ranking/HomeRankingScreen.kt
@@ -1,14 +1,24 @@
 package com.chan.home.composables.ranking
 
 import android.util.Log
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.chan.android.model.ProductsModel
 import com.chan.android.ui.CommonProductsCard
 import com.chan.android.ui.theme.Spacing
 import com.chan.home.home.HomeContract
@@ -20,28 +30,58 @@ fun HomeRankingScreen(
 ) {
 
     LaunchedEffect(Unit) {
-        Log.d("rankingInfo"," LaunchedEffect ")
         onEvent(HomeContract.Event.HomeRankingEvent.RankingProductsLoad)
     }
 
-    //무한 스크롤
-    state.homeRankingState.rankingProducts?.let { rankingProducts ->
-        val products = rankingProducts.collectAsLazyPagingItems()
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(2),
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(Spacing.spacing2)
-        ) {
-            items(products.itemCount) { index ->
-                products[index]?.let { product ->
-                    CommonProductsCard(
-                        product = product,
-                        onClick = { onEvent(HomeContract.Event.OnProductClicked(it)) },
-                        onLikeClick = { onEvent(HomeContract.Event.OnLikedClick(it)) },
-                        onCartClick = { onEvent(HomeContract.Event.OnCartClicked(it)) }
-                    )
-                }
+    val products = state.homeRankingState.rankingProducts?.collectAsLazyPagingItems()
+
+    products?.let { lazyItems ->
+        when (val refreshState = lazyItems.loadState.refresh) {
+            is LoadState.Loading -> LoadingProducts()
+            is LoadState.Error -> ErrorProducts(refreshState, lazyItems)
+            is LoadState.NotLoading -> SuccessProducts(lazyItems, state, onEvent)
+        }
+    } ?: run {
+        LoadingProducts()
+    }
+}
+
+@Composable
+private fun SuccessProducts(
+    lazyItems: LazyPagingItems<ProductsModel>,
+    state: HomeContract.State,
+    onEvent: (HomeContract.Event) -> Unit
+) {
+    LazyVerticalGrid(columns = GridCells.Fixed(2)) {
+        items(lazyItems.itemCount) { index ->
+            lazyItems[index]?.let { product ->
+                CommonProductsCard(
+                    product = product,
+                    onClick = { onEvent(HomeContract.Event.OnProductClicked(it)) },
+                    onLikeClick = { onEvent(HomeContract.Event.OnLikedClick(it)) },
+                    onCartClick = { onEvent(HomeContract.Event.OnCartClicked(it)) }
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun ErrorProducts(refreshState: LoadState.Error, lazyItems: LazyPagingItems<ProductsModel>) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text("데이터를 불러오지 못했습니다: ${refreshState.error.message}")
+            Spacer(Modifier.height(Spacing.spacing2))
+            Button(onClick = { lazyItems.retry() }) {
+                Text("다시 시도")
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingProducts() {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
     }
 }

--- a/feature/home/src/main/java/com/chan/home/data/repository/RankingRepositoryImpl.kt
+++ b/feature/home/src/main/java/com/chan/home/data/repository/RankingRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.chan.home.data.repository
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.chan.database.dao.ProductsDao
+import com.chan.domain.ProductsVO
+import com.chan.home.data.mapper.toProductsVO
+import com.chan.home.domain.repository.RankingRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class RankingRepositoryImpl @Inject constructor(
+    private val productsDao: ProductsDao
+) : RankingRepository {
+    override fun getAllProducts(): Flow<PagingData<ProductsVO>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = 30,
+                enablePlaceholders = false
+            ),
+            pagingSourceFactory = { productsDao.getAllProductsPaging() }
+        ).flow.map { pagingData ->
+            pagingData.map { it.toProductsVO() }
+        }
+    }
+}

--- a/feature/home/src/main/java/com/chan/home/domain/repository/RankingRepository.kt
+++ b/feature/home/src/main/java/com/chan/home/domain/repository/RankingRepository.kt
@@ -1,0 +1,9 @@
+package com.chan.home.domain.repository
+
+import androidx.paging.PagingData
+import com.chan.domain.ProductsVO
+import kotlinx.coroutines.flow.Flow
+
+interface RankingRepository {
+    fun getAllProducts() : Flow<PagingData<ProductsVO>>
+}

--- a/feature/home/src/main/java/com/chan/home/domain/usecase/RankingUseCase.kt
+++ b/feature/home/src/main/java/com/chan/home/domain/usecase/RankingUseCase.kt
@@ -1,0 +1,14 @@
+package com.chan.home.domain.usecase
+
+import com.chan.home.domain.repository.RankingRepository
+import javax.inject.Inject
+
+data class RankingUseCase (
+    val rankingProductsUseCase: RankingProductsUseCase
+)
+
+class RankingProductsUseCase @Inject constructor(
+    private val rankingRepository: RankingRepository
+) {
+    operator fun invoke() = rankingRepository.getAllProducts()
+}

--- a/feature/home/src/main/java/com/chan/home/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/chan/home/home/HomeContract.kt
@@ -25,8 +25,8 @@ class HomeContract {
         data class OnLikedClick(val productId: String) : Event()
         data class OnCartClicked(val productId: String) : Event()
 
-        sealed class HomeRankingEvent : ViewEvent {
-            object RankingProductsLoad : Event()
+        sealed class HomeRankingEvent : Event() {
+            object RankingProductsLoad : HomeRankingEvent()
         }
     }
 
@@ -40,21 +40,14 @@ class HomeContract {
         val selectedRankingTabIndex: Int = 0,
         val isLoading: Boolean = false,
         val isError: Boolean = false,
-
-        val homeRankingState: HomeRankingState = HomeRankingState()
     ) : ViewState
-
-
-    data class HomeRankingState(
-        val rankingProducts: Flow<PagingData<ProductsModel>>? = null
-    )
 
     sealed class Effect : ViewEffect {
         data class ShowError(val message: String) : Effect()
-        sealed class Navigation : ViewEffect {
-            data class ToProductDetailRoute(val productId: String) : Effect()
-            data class ToCartPopupRoute(val productId: String) : Effect()
-            data class ToCartRoute(val productId: String) : Effect()
+        sealed class Navigation : Effect() {
+            data class ToProductDetailRoute(val productId: String) : Navigation()
+            data class ToCartPopupRoute(val productId: String) : Navigation()
+            data class ToCartRoute(val productId: String) : Navigation()
         }
     }
 }

--- a/feature/home/src/main/java/com/chan/home/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/chan/home/home/HomeContract.kt
@@ -1,5 +1,6 @@
 package com.chan.home.home
 
+import androidx.paging.PagingData
 import com.chan.android.ViewEffect
 import com.chan.android.ViewEvent
 import com.chan.android.ViewState
@@ -8,6 +9,7 @@ import com.chan.home.model.HomeBannerModel
 import com.chan.home.model.HomeRankingCategoryTabModel
 import com.chan.home.model.HomeSaleProductModel
 import com.chan.home.model.HomeTabItem
+import kotlinx.coroutines.flow.Flow
 
 class HomeContract {
     sealed class Event : ViewEvent {
@@ -22,10 +24,14 @@ class HomeContract {
         data class OnProductClicked(val productId: String) : Event()
         data class OnLikedClick(val productId: String) : Event()
         data class OnCartClicked(val productId: String) : Event()
+
+        sealed class HomeRankingEvent : ViewEvent {
+            object RankingProductsLoad : Event()
+        }
     }
 
     data class State(
-        val topBars : List<HomeTabItem> = emptyList(),
+        val topBars: List<HomeTabItem> = emptyList(),
         val bannerList: List<HomeBannerModel> = emptyList(),
         val popularProducts: List<ProductsModel> = emptyList(),
         val rankingCategoryTabs: List<HomeRankingCategoryTabModel> = emptyList(),
@@ -33,8 +39,15 @@ class HomeContract {
         val saleProductList: List<HomeSaleProductModel> = emptyList(),
         val selectedRankingTabIndex: Int = 0,
         val isLoading: Boolean = false,
-        val isError: Boolean = false
+        val isError: Boolean = false,
+
+        val homeRankingState: HomeRankingState = HomeRankingState()
     ) : ViewState
+
+
+    data class HomeRankingState(
+        val rankingProducts: Flow<PagingData<ProductsModel>>? = null
+    )
 
     sealed class Effect : ViewEffect {
         data class ShowError(val message: String) : Effect()


### PR DESCRIPTION
### **📌 Issue**
- #30  

### **🔖 요약**
1. 상품 리스트 + Paging3 적용

### **🛠 작업 내용**
-  Paging3 라이브러리를 적용하여, 페이지 당 30개의 데이터를 가져오도록 구현하였습니다. Retrofit을 통해 서버와 연결하지 않기때문에 `ProductsDao`에서 `PagingSource`를 통해 연동을 진행하였습니다.
- `collectAsLazyPagingItems`를 통해 무한 스크롤 및 오류 처리를 구현하였습니다.
