### PR TITLE
cartViewModel init 테스트 코드 작성

### DIFF
--- a/feature/cart/src/test/java/com/chan/cart/CartViewModelTest.kt
+++ b/feature/cart/src/test/java/com/chan/cart/CartViewModelTest.kt
@@ -1,0 +1,55 @@
+package com.chan.cart
+
+import app.cash.turbine.test
+import com.chan.auth.domain.usecase.CheckSessionUseCase
+import com.chan.cart.domain.usecase.CartUseCases
+import com.chan.cart.fixture.CartItemFixture
+import com.chan.cart.proto.CartItem
+import com.chan.cart.rule.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+
+@ExperimentalCoroutinesApi
+class CartViewModelTest: CartViewModelTestBase() {
+
+    @Test
+    fun `init - viewModel이 생성되면 장바구니 상품을 정상적으로 불러온다`() = runTest {
+        //Given
+        val mockCartItems = CartItemFixture.createCarItems()
+
+        //상품 목록
+        mockSetup.setupCartItems(mockCartItems)
+        //세션이 유효하다고 가정
+        mockSetup.setupSessionValid(true)
+
+        //When
+        createCartViewModel()
+        advanceUntilIdle()
+
+        //Then
+        viewModel.viewState.test {
+            val state = awaitItem()
+
+            assertEquals(2, state.cartInProducts.size)
+            assertEquals("p1", state.cartInProducts[0].productId)
+            assertEquals(2, state.cartInProducts[0].quantity)
+
+            assertEquals(3, state.totalProductsCount)
+            assertEquals(31000, state.totalPrice)
+            assertTrue(state.allSelected)
+        }
+    }
+
+
+}

--- a/feature/cart/src/test/java/com/chan/cart/CartViewModelTestBase.kt
+++ b/feature/cart/src/test/java/com/chan/cart/CartViewModelTestBase.kt
@@ -1,0 +1,35 @@
+package com.chan.cart
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.chan.auth.domain.usecase.CheckSessionUseCase
+import com.chan.cart.domain.usecase.CartUseCases
+import com.chan.cart.rule.MainDispatcherRule
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Rule
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExperimentalCoroutinesApi
+abstract class CartViewModelTestBase {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    protected val checkSessionUseCase: CheckSessionUseCase = mockk(relaxed = true)
+    protected val cartUseCases: CartUseCases = mockk(relaxed = true)
+
+    protected lateinit var viewModel: CartViewModel
+    protected lateinit var mockSetup: MockSetup
+
+
+    @Before
+    fun baseSetUp() {
+        mockSetup = MockSetup(cartUseCases, checkSessionUseCase)
+        mockSetup.setupCartItems(emptyList())
+    }
+
+    protected fun createCartViewModel() {
+        viewModel = CartViewModel(checkSessionUseCase, cartUseCases)
+    }
+}

--- a/feature/cart/src/test/java/com/chan/cart/MockSetup.kt
+++ b/feature/cart/src/test/java/com/chan/cart/MockSetup.kt
@@ -1,0 +1,29 @@
+package com.chan.cart
+
+import com.chan.auth.domain.usecase.CheckSessionUseCase
+import com.chan.cart.domain.usecase.CartUseCases
+import com.chan.cart.proto.CartItem
+import io.mockk.coEvery
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * Mock 설정 로직 분리 (Single Responsibility)
+ * 책임: Mock 객체만 설정
+ */
+class MockSetup(
+    private val cartUseCases: CartUseCases,
+    private val checkSessionUseCase: CheckSessionUseCase
+) {
+
+    fun setupCartItems(items: List<CartItem> = emptyList()) {
+        coEvery { cartUseCases.cartItemUseCase(any()) } returns flowOf(items)
+    }
+
+    fun setupSessionValid(isValid: Boolean = true) {
+        coEvery { checkSessionUseCase.invoke() } returns isValid
+    }
+
+    fun setupError(exception: Exception = Exception("Test error")) {
+        coEvery { cartUseCases.cartItemUseCase(any()) } throws exception
+    }
+}

--- a/feature/cart/src/test/java/com/chan/cart/fixture/CartItemFixture.kt
+++ b/feature/cart/src/test/java/com/chan/cart/fixture/CartItemFixture.kt
@@ -1,0 +1,24 @@
+package com.chan.cart.fixture
+
+import com.chan.cart.proto.CartItem
+
+object CartItemFixture {
+    fun createCarItems() = listOf(
+        CartItem.newBuilder()
+            .setProductId("p1")
+            .setProductName("Test Product 1")
+            .setOriginPrice(10000)
+            .setDiscountedPrice(8000)
+            .setQuantity(2)
+            .setIsSelected(true)
+            .build(),
+        CartItem.newBuilder()
+            .setProductId("p2")
+            .setProductName("Test Product 2")
+            .setOriginPrice(20000)
+            .setDiscountedPrice(15000)
+            .setQuantity(1)
+            .setIsSelected(true)
+            .build()
+    )
+}

--- a/feature/cart/src/test/java/com/chan/cart/rule/MainDispatcherRule.kt
+++ b/feature/cart/src/test/java/com/chan/cart/rule/MainDispatcherRule.kt
@@ -1,0 +1,26 @@
+package com.chan.cart.rule
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class MainDispatcherRule : TestRule {
+    private val testDispatcher = StandardTestDispatcher()
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                Dispatchers.setMain(testDispatcher)
+                try {
+                    base.evaluate()
+                } finally {
+                    Dispatchers.resetMain()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### **📌 Issue**
- 장바구니 init 테스트 코드 작성

### **🔖 요약**
1. CartViewModel 안정성 강화를 위한 유닛 테스트 도입

### **🛠 작업 내용**
1. `MainDispatcherRule`
 - 코루틴 비동기 코드를 테스트 환경에서 안정적으로 실행하도록 설정하였습니다.
2. `CartItemFixture`
 - Mock Data를 생성합니다.
3. `MockSetup`
 - Mock Data 테스트 행동을 정의합니다.
4. `CartViewModelTestBase`
 - CartViewModel 테스트에 필요한 공통 환경입니다.
5. `CartViewModelTest`
 - 실제 테스트를 진행하는 공간입니다.

### **❓ 질문**
처음 작성하다 보니, 잘 작성되었는 지 궁금합니다!
또한 실무에서 이런 식으로 사용하는 지 궁금합니다!
